### PR TITLE
CI: unused images

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,22 @@
+name: Find unused images
+
+on:
+  push:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  editor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Find unused versions
+        shell: pwsh
+        run: |
+          # $usedVersions = scripts/used-versions.ps1
+          # Write-Host $usedVersions
+          $auth = @{Authorization = "Token ${env:GITHUB_TOKEN}"; Accept = 'application/vnd.github.machine-man-preview+json'}
+          Invoke-WebRequest -Headers $headers https://api.github.com/orgs/getsentry/packages/container/unity-docker

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,4 +18,10 @@ jobs:
         run: |
           $usedVersions = ./scripts/used-versions.ps1
           Write-Host "Versions currently in use: $usedVersions"
+          foreach ($prefix in @('2019', '2020', '2021'))
+          {
+              $usedVersions += (./scripts/latest-version.ps1 $prefix).split("/")[0]
+          }
+          $usedVersions = $usedVersions | Sort-Object -Unique
+          Write-Host "Versions currently in use (including latest): $usedVersions"
           ./scripts/obsolete-images.ps1 $usedVersions

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Find unused versions
         shell: pwsh
         run: |
-          # $usedVersions = scripts/used-versions.ps1
-          # Write-Host $usedVersions
-          $auth = @{Authorization = "Token ${$env:GITHUB_TOKEN}"; Accept = 'application/vnd.github.machine-man-preview+json'}
-          Invoke-WebRequest -Headers $headers https://api.github.com/orgs/getsentry/packages/container/unity-docker
+          $usedVersions = ./scripts/used-versions.ps1
+          Write-Host "Versions currently in use: $usedVersions"
+          ./scripts/obsolete-images.ps1 $usedVersions

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -18,5 +18,5 @@ jobs:
         run: |
           # $usedVersions = scripts/used-versions.ps1
           # Write-Host $usedVersions
-          $auth = @{Authorization = "Token ${env:GITHUB_TOKEN}"; Accept = 'application/vnd.github.machine-man-preview+json'}
+          $auth = @{Authorization = "Token ${$env:GITHUB_TOKEN}"; Accept = 'application/vnd.github.machine-man-preview+json'}
           Invoke-WebRequest -Headers $headers https://api.github.com/orgs/getsentry/packages/container/unity-docker

--- a/scripts/obsolete-images.ps1
+++ b/scripts/obsolete-images.ps1
@@ -1,0 +1,38 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string[]] $usedVersions
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+function isUsed([string] $link)
+{
+    foreach ($version in $usedVersions)
+    {
+        if ($link.Contains($version))
+        {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+$links = (Invoke-WebRequest https://github.com/getsentry/unity-docker/pkgs/container/unity-docker/versions).Links.Href
+$linksUnused = $links | Select-String -Pattern "tag=editor-ubuntu" | Where-Object { !(isUsed $_) }
+
+if ($linksUnused.Length -gt 0)
+{
+    Write-Host "The following versions are not used, you can delete them now"
+    foreach ($link in $linksUnused)
+    {
+        Write-Output "https://github.com/$link"
+    }
+    # Because we can't delete automatically yet, fail the CI here if there are any items the user needs to delete manually
+    exit 1
+}
+else
+{
+    Write-Host "There are no unused versions, all ${$links.Length} are currently in use"
+}

--- a/scripts/used-versions.ps1
+++ b/scripts/used-versions.ps1
@@ -1,0 +1,54 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+$repository = "https://github.com/getsentry/sentry-unity.git"
+$checkoutDir = "temp-checkout"
+$versionsScript = "scripts/ci-env.ps1"
+$versionsBases = @("unity2019", "unity2020", "unity2021", "unity2022")
+
+if (Test-Path $checkoutDir)
+{
+    Write-Host "Checkout dir already exists, removing"
+    Remove-Item -Recurse -Force $checkoutDir
+}
+git clone -v $repository $checkoutDir
+
+try
+{
+    $resultSet = New-Object System.Collections.Generic.HashSet[string]
+
+    Push-Location $checkoutDir
+    $branches = git for-each-ref --format='%(refname:short)' refs/remotes/origin/
+    foreach ($branch in $branches)
+    {
+        git checkout --quiet $branch
+        if (!(Test-Path $versionsScript))
+        {
+            Write-Warning "Skipping branch $branch - $versionsScript not found"
+            continue
+        }
+        foreach ($arg in $versionsBases)
+        {
+            try
+            {
+                $usedVersion = & $versionsScript $arg
+                Write-Host "Branch $branch uses $usedVersion"
+                $resultSet.Add($usedVersion) > $null
+            }
+            catch
+            {
+                $exception = $_
+                if (!($exception.ToString().Replace('Unkown', 'Unknown').StartsWith('Unknown variable')))
+                {
+                    Write-Error "Failed to determine exact version for '$arg' on branch $branch - $exception"
+                }
+            }
+        }
+    }
+    Write-Host "-----------------------------------------------------------------------"
+    Write-Output ($resultSet | Sort-Object)
+}
+finally
+{
+    Pop-Location
+}


### PR DESCRIPTION
Closes #1 

The current version requires manually deleting the old images (which I cannot do BTW). We'd need a token with enough credentials to do it automatically in CI. I've tried it like this and couldn't even use the rest API to list the existing versions, despite them being publicly available:

```powershell
  $auth = @{Authorization = "Token ${$env:GITHUB_TOKEN}"; Accept = 'application/vnd.github.machine-man-preview+json'}
  Invoke-WebRequest -Headers $headers https://api.github.com/orgs/getsentry/packages/container/unity-docker
```
```
shell: /usr/bin/pwsh -command ". '{0}'"
Invoke-WebRequest: /home/runner/work/_temp/64b046cc-[3](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:3)a11-[4](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:4)2e0-b0df-[5](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:5)[6](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:6)2[7](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:7)03c[8](https://github.com/getsentry/unity-docker/runs/5972377069?check_suite_focus=true#step:3:8)c5ae.ps1:5
Line |
   5 |  Invoke-WebRequest -Headers $headers https://api.github.com/orgs/getse …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | {"message":"Requires
     | authentication","documentation_url":"https://docs.github.com/rest/reference/packages#get-a-package-for-an-organization"}
```